### PR TITLE
Added Gaussian window function.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ set(Aquila_HEADERS
     aquila/source/window/BarlettWindow.h
     aquila/source/window/BlackmanWindow.h
     aquila/source/window/FlattopWindow.h
+    aquila/source/window/GaussianWindow.h
     aquila/source/window/HammingWindow.h
     aquila/source/window/HannWindow.h
     aquila/source/window/RectangularWindow.h
@@ -114,6 +115,7 @@ set(Aquila_SOURCES
     aquila/source/window/BarlettWindow.cpp
     aquila/source/window/BlackmanWindow.cpp
     aquila/source/window/FlattopWindow.cpp
+    aquila/source/window/GaussianWindow.cpp
     aquila/source/window/HammingWindow.cpp
     aquila/source/window/HannWindow.cpp
     aquila/transform/Dft.cpp

--- a/aquila/source.h
+++ b/aquila/source.h
@@ -35,6 +35,7 @@
 #include "source/window/BarlettWindow.h"
 #include "source/window/BlackmanWindow.h"
 #include "source/window/FlattopWindow.h"
+#include "source/window/GaussianWindow.h"
 #include "source/window/HammingWindow.h"
 #include "source/window/HannWindow.h"
 #include "source/window/RectangularWindow.h"

--- a/aquila/source/window/GaussianWindow.cpp
+++ b/aquila/source/window/GaussianWindow.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file GaussianWindow.cpp
+ *
+ * Gaussian (triangular) window. Based on the formula given at:
+ * http://en.wikipedia.org/wiki/Window_function#Gaussian_window
+ *
+ * This file is part of the Aquila DSP library.
+ * Aquila is free software, licensed under the MIT/X11 License. A copy of
+ * the license is provided with the library in the LICENSE file.
+ *
+ * @package Aquila
+ * @version 3.0.0-dev
+ * @author Chris Vandevelde
+ * @date 2007-2014
+ * @license http://www.opensource.org/licenses/mit-license.php MIT
+ * @since 3.0.0
+ */
+
+#include "GaussianWindow.h"
+#include <cmath>
+
+namespace Aquila
+{
+    /**
+     * Creates Gaussian window of given size, with optional sigma parameter.
+     *
+     * @param size window length
+     * @param sigma standard deviation
+     */
+    GaussianWindow::GaussianWindow(std::size_t size, double sigma/* = 0.5*/):
+        SignalSource()
+    {
+        m_data.reserve(size);
+        for (std::size_t n = 0; n < size; ++n)
+        {
+            m_data.push_back(
+                std::exp((-0.5) * std::pow((n - (size - 1.0) / 2.0)/(sigma * (size - 1.0) / 2.0), 2.0))
+            );
+        }
+    }
+}

--- a/aquila/source/window/GaussianWindow.h
+++ b/aquila/source/window/GaussianWindow.h
@@ -1,0 +1,38 @@
+/**
+ * @file GaussianWindow.h
+ *
+ * Gaussian (triangular) window. Based on the formula given at:
+ * http://en.wikipedia.org/wiki/Window_function#Gaussian_window
+ *
+ * This file is part of the Aquila DSP library.
+ * Aquila is free software, licensed under the MIT/X11 License. A copy of
+ * the license is provided with the library in the LICENSE file.
+ *
+ * @package Aquila
+ * @version 3.0.0-dev
+ * @author Chris Vandevelde
+ * @date 2007-2014
+ * @license http://www.opensource.org/licenses/mit-license.php MIT
+ * @since 3.0.0
+ */
+
+#ifndef GAUSSIANWINDOW_H
+#define GAUSSIANWINDOW_H
+
+#include "../../global.h"
+#include "../SignalSource.h"
+#include <cstddef>
+
+namespace Aquila
+{
+    /**
+     * Creates Gaussian window of given size, with optional sigma parameter.
+     */
+    class AQUILA_EXPORT GaussianWindow : public SignalSource
+    {
+    public:
+        GaussianWindow(std::size_t size, double sigma = 0.5);
+    };
+}
+
+#endif // GAUSSIANWINDOW_H

--- a/tests/source/window/GaussianWindow.cpp
+++ b/tests/source/window/GaussianWindow.cpp
@@ -1,0 +1,15 @@
+#include "aquila/global.h"
+#include "aquila/source/window/GaussianWindow.h"
+#include <unittestpp.h>
+#include <cstddef>
+
+SUITE(GaussianWindow)
+{
+    TEST(NonZeroAtEnds)
+    {
+        const std::size_t SIZE = 4;
+        Aquila::GaussianWindow w(SIZE);
+        CHECK(w.sample(0) > 0.000001);
+        CHECK(w.sample(SIZE - 1) > 0.000001);
+    }
+}


### PR DESCRIPTION
I'm using Aquila in a personal project based on a MATLAB prototype, and I needed a Gaussian window function to do some blurring, similar to MATLAB's gausswin() (see http://www.mathworks.com/help/signal/ref/gausswin.html). This pull adds that function based on the formula at http://en.wikipedia.org/wiki/Window_function#Gaussian_window, as well as a (admittedly-basic) test.

As a demonstration, here's the MATLAB output:

``` matlab
>> gausswin(10)
ans =
    0.0439
    0.1510
    0.3812
    0.7066
    0.9622
    0.9622
    0.7066
    0.3812
    0.1510
    0.0439
```

and here's the output of the Aquila::GaussianWindow() function with the same size and their default standard deviation (they use α = 1/σ as input, default α is 2.5, so σ = 0.4).

``` C++
Aquila::GaussianWindow gaussian(10, 0.4)
0.0439369
0.151007
0.381171
0.706648
0.962154
0.962154
0.706648
0.381171
0.151007
0.0439369
```
