### PR TITLE
Fixed Windows Compilation

### DIFF
--- a/aquila/functions.h
+++ b/aquila/functions.h
@@ -115,7 +115,13 @@ namespace Aquila
         {
             return 2 * n;
         }
+        
+        #ifdef MSVC
+        size_t size_in_bits = sizeof(Integer) * 8;
+        #else
         constexpr size_t size_in_bits = sizeof(Integer) * 8;
+        #endif
+
         for (size_t shift = 1; shift < size_in_bits; shift *= 2)
         {
             n |= (n >> shift);

--- a/aquila/functions.h
+++ b/aquila/functions.h
@@ -116,7 +116,7 @@ namespace Aquila
             return 2 * n;
         }
         
-        #ifdef MSVC
+        #ifdef _MSC_VER 
         size_t size_in_bits = sizeof(Integer) * 8;
         #else
         constexpr size_t size_in_bits = sizeof(Integer) * 8;


### PR DESCRIPTION
Visual Studio doesn't support constexpr yet, so this should fix compilation for Windows.